### PR TITLE
overload Geo::distanceFormat to handle Double

### DIFF
--- a/transitclock/src/main/java/org/transitclock/ipc/data/IpcVehicleComplete.java
+++ b/transitclock/src/main/java/org/transitclock/ipc/data/IpcVehicleComplete.java
@@ -27,7 +27,6 @@ import org.transitclock.core.BlockAssignmentMethod;
 import org.transitclock.core.SpatialMatch;
 import org.transitclock.core.TemporalDifference;
 import org.transitclock.core.VehicleState;
-import org.transitclock.db.structs.HoldingTime;
 import org.transitclock.db.structs.Trip;
 import org.transitclock.utils.Geo;
 import org.transitclock.utils.Time;

--- a/transitclock/src/main/java/org/transitclock/utils/Geo.java
+++ b/transitclock/src/main/java/org/transitclock/utils/Geo.java
@@ -74,6 +74,27 @@ public class Geo {
 	}
 
 	/**
+	 * For formatting distances in meters to consistent 2 decimal places.
+	 * Appends "m" to indicate units.
+	 * 
+	 * @param arg
+	 * @return
+	 */
+	public static String distanceFormat(Double arg) {
+		// Handle NaN and other special cases
+		if (arg == null)
+			return "null";
+		if (arg.isNaN())
+			return "NaN";
+		if (arg == Double.MAX_VALUE) 
+			return "Double.MAX_VALUE";
+		
+		// Not a special case so output the value with just two digits
+		// past decimal place and append "m" to indicate meters.
+		return twoDigitFormat.format(arg) + "m";
+	}
+
+	/**
 	 * Outputs arg with just a single digit. No other formatting is done.
 	 * Useful when want to output speed or heading but don't want to
 	 * include units.


### PR DESCRIPTION
@vsperez I tested this branch, all the maps work but this function did need overloading. It was being called from `IpcVehicleComplete::toString` and causing a NullPointerException for me.